### PR TITLE
feat: adding version file input

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Example: `major-release: true`
 **Required:** Pypi username for deployment
 ### `pypi-password`
 **Required:** Pypi password for deployment
+### `version-file-path`
+**Required:** Path to the file containing __version__ = <version_number> , where version_number will be incremented and commited to the main branch. This should be a relative path from the root of the repo.
+### `main-branch`
+**Optional:** Name of the default branch in the repo. Usually is main or master (old). Defaults to main.
 
 ## Known limitations
 

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
     - name: Version bump
       run: |
         # Bump version = <number> in version file
-        sed -i "s/^__version__ = .*/__version__ = ${{ steps.tag_generation.outputs.new_tag }}/" ${{ inputs.version-file-path }}
+        sed -i "s/^__version__ = .*/__version__ = \"${{ steps.tag_generation.outputs.new_tag }}\"/" ${{ inputs.version-file-path }}
         git add ${{ inputs.version-file-path }}
         git commit -m "Automatic version bump to ${{ steps.tag_generation.outputs.new_tag }}"
         git push origin ${{ inputs.main-branch }}

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   pypi-password:
     description: 'Pypi password for deployment'
     required: true
+  version-file-path:
+    description: 'Path to the file containing __version__ = '
+    required: true
   main-branch:
     description: 'Name of the main branch in the repo'
     default: 'main'
@@ -59,11 +62,9 @@ runs:
 
     - name: Version bump
       run: |
-        # Bump version = <number> in setup.cfg
-        sed -i "s/^version = .*/version = ${{ steps.tag_generation.outputs.new_tag }}/" setup.cfg
-        # Verify the change
-        python3 -c "from configparser import ConfigParser; c = ConfigParser(); c.read('setup.cfg'); assert c['metadata']['version'] == '${{ steps.tag_generation.outputs.new_tag }}', 'Version was not updated correctly in setup.cfg'"
-        git add setup.cfg
+        # Bump version = <number> in version file
+        sed -i "s/^__version__ = .*/__version__ = ${{ steps.tag_generation.outputs.new_tag }}/" ${{ inputs.version-file-path }}
+        git add ${{ inputs.version-file-path }}
         git commit -m "Automatic version bump to ${{ steps.tag_generation.outputs.new_tag }}"
         git push origin ${{ inputs.main-branch }}
       shell: bash


### PR DESCRIPTION
Letting users provide version file path to accommodate different places repos could store them.