### PR TITLE
chore(ci): replace deprecated set-output workflow command (FIR-23850)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ runs:
       id: tag_resolution
       run: |
         TAG=${{ steps.tag_generation.outputs.new_tag }}${{ inputs.version-override }}
-        echo "::set-output name=new_tag::$TAG"
+        echo "new_tag=\"${TAG}\"" >> "${GITHUB_OUTPUT}"
       shell: bash
 
     - name: Version bump

--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ runs:
       id: tag_resolution
       run: |
         TAG=${{ steps.tag_generation.outputs.new_tag }}${{ inputs.version-override }}
-        echo "new_tag=\"${TAG}\"" >> "${GITHUB_OUTPUT}"
+        echo "new_tag=${TAG}" >> "${GITHUB_OUTPUT}"
       shell: bash
 
     - name: Version bump


### PR DESCRIPTION
**Background**

`set-output` was supposed to be deprecated 31 May (in 5 days). They delayed, but it needs done anyway

**Details**

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

**Testing**

It's a drop in replacement, eyeball scan for typos should do.