### PR TITLE
ci: use python 3.8

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,10 +30,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Updated python version from 3.7 to 3.8