### PR TITLE
ci: upgrade the action to use python 3.14 FIR-51696

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,10 +30,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+    - name: Set up Python 3.14
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: '3.14'
     
     - name: Install dependencies
       run: |


### PR DESCRIPTION
python 3.8 is not supported anymore. Upgrade to the latest version of python 3.14. 

The problem with 3.8 was that is was checking the pyproject.toml that had a different spec than the latest spec PEP 639. This prevents publishing of the langchain project