### PR TITLE
ci: fix the case where changelog has quotes FIR-51696

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
       run: |
         OLD_TAG=$(git describe --tags --abbrev=0)
         echo "Old tag was ${OLD_TAG}"
-        CHANGE_LOG=$(git log $OLD_TAG..HEAD --pretty=format:%s)
+        CHANGE_LOG=$(git log "$OLD_TAG"..HEAD --pretty=format:%s | sed 's/"/\\"/g')
         echo "changes<<EOF" >> $GITHUB_OUTPUT
         echo "$CHANGE_LOG" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
When the commit log has quotes the generate action seems to fail: 

Getting this error: 
generate_version_tag.py: error: unrecognized arguments: bump to 0.1.1